### PR TITLE
Update Lombok

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -144,10 +144,10 @@ dependencies {
     testImplementation group: 'com.squareup.okhttp3', name: 'okhttp', version: '4.10.0'
 
     // Lombok.
-    compileOnly group: 'org.projectlombok', name: 'lombok', version: '1.18.26'
-    annotationProcessor group: 'org.projectlombok', name: 'lombok', version: '1.18.26'
-    testCompileOnly group: 'org.projectlombok', name: 'lombok', version: '1.18.26'
-    testAnnotationProcessor group: 'org.projectlombok', name: 'lombok', version: '1.18.26'
+    compileOnly group: 'org.projectlombok', name: 'lombok', version: '1.18.30'
+    annotationProcessor group: 'org.projectlombok', name: 'lombok', version: '1.18.30'
+    testCompileOnly group: 'org.projectlombok', name: 'lombok', version: '1.18.30'
+    testAnnotationProcessor group: 'org.projectlombok', name: 'lombok', version: '1.18.30'
 }
 
 configurations.configureEach {


### PR DESCRIPTION
Change the Lombok version to 1.18.30 to avoid compilation errors when using Java SDK 21.