### PR TITLE
Multi mob rewards not found fix | Missing sceneTag Execs | Healing items by HP %

### DIFF
--- a/src/main/java/emu/grasscutter/game/player/PlayerBuffManager.java
+++ b/src/main/java/emu/grasscutter/game/player/PlayerBuffManager.java
@@ -110,7 +110,7 @@ public final class PlayerBuffManager extends BasePlayerManager {
 
                                             var maxHp = target.getFightProperty(FightProperty.FIGHT_PROP_MAX_HP);
                                             var amount =
-                                                    ability.amount.get() + ability.amountByTargetMaxHPRatio.get() * maxHp;
+                                                    ability.amount.get() + ability.amountByCasterMaxHPRatio.get() * maxHp;
 
                                             target.getAsEntity().heal(amount);
                                             shouldHeal = true;

--- a/src/main/java/emu/grasscutter/game/quest/exec/ExecAddSceneTag.java
+++ b/src/main/java/emu/grasscutter/game/quest/exec/ExecAddSceneTag.java
@@ -1,0 +1,20 @@
+package emu.grasscutter.game.quest.exec;
+
+import emu.grasscutter.data.excels.quest.QuestData;
+import emu.grasscutter.game.quest.*;
+import emu.grasscutter.game.quest.enums.QuestExec;
+import emu.grasscutter.game.quest.handlers.QuestExecHandler;
+import emu.grasscutter.scripts.ScriptLib;
+import java.util.Arrays;
+
+@QuestValueExec(QuestExec.QUEST_EXEC_ADD_SCENE_TAG)
+public final class ExecAddSceneTag extends QuestExecHandler {
+    @Override
+    public boolean execute(GameQuest quest, QuestData.QuestExecParam condition, String... paramStr) {
+        var param =
+                Arrays.stream(paramStr).filter(i -> !i.isBlank()).mapToInt(Integer::parseInt).toArray();
+		quest.getOwner().getProgressManager().addSceneTag(param[0], param[1]);
+		
+        return true;
+    }
+}

--- a/src/main/java/emu/grasscutter/game/quest/exec/ExecDelSceneTag.java
+++ b/src/main/java/emu/grasscutter/game/quest/exec/ExecDelSceneTag.java
@@ -1,0 +1,19 @@
+package emu.grasscutter.game.quest.exec;
+
+import emu.grasscutter.data.excels.quest.QuestData;
+import emu.grasscutter.game.quest.*;
+import emu.grasscutter.game.quest.enums.QuestExec;
+import emu.grasscutter.game.quest.handlers.QuestExecHandler;
+import java.util.Arrays;
+
+@QuestValueExec(QuestExec.QUEST_EXEC_DEL_SCENE_TAG)
+public final class ExecDelSceneTag extends QuestExecHandler {
+    @Override
+    public boolean execute(GameQuest quest, QuestData.QuestExecParam condition, String... paramStr) {
+        var param =
+                Arrays.stream(paramStr).filter(i -> !i.isBlank()).mapToInt(Integer::parseInt).toArray();
+		quest.getOwner().getProgressManager().delSceneTag(param[0], param[1]);
+		
+        return true;
+    }
+}

--- a/src/main/java/emu/grasscutter/game/world/WorldDataSystem.java
+++ b/src/main/java/emu/grasscutter/game/world/WorldDataSystem.java
@@ -52,7 +52,7 @@ public class WorldDataSystem extends BaseGameSystem {
         var investigationMonsterData =
                 GameData.getInvestigationMonsterDataMap().values().parallelStream()
                         .filter(imd -> imd.getMonsterIdList() != null && !imd.getMonsterIdList().isEmpty())
-                        .filter(imd -> imd.getMonsterIdList().get(0) == monsterId)
+                        .filter(imd -> imd.getMonsterIdList().contains(monsterId))
                         .findFirst();
 
         return investigationMonsterData


### PR DESCRIPTION
## Description
Few Fixes that may help in the future if more thing are implemented
1- Fixed Healing items not healing (hp %) (Fix by Gabbyxo97)
2- Fixed Bosses with multiple mob ids not finding rewards (multi variant mobs)
3- Added SceneTag exec (needed if quests are someday working again) 

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [x] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.
